### PR TITLE
Fix: Munin cyrus-imapd hangs without connections

### DIFF
--- a/munin/cyrus-imapd
+++ b/munin/cyrus-imapd
@@ -74,6 +74,14 @@ if [ "$1" = "config" ]; then
 fi
 
 procs=$(lsof +d ${PROCDIR} | grep -v NAME | awk '{print $9}')
+
+if [ ${#procs} -lt 2 ]; then
+    echo "connections.value 0"
+    echo "authenticated_users.value 0"
+    echo "unique_users.value 0"
+    exit 0
+fi
+
 # Print the number of connections to the imap server
 echo "connections.value $(echo "${procs}" | wc -l)"
 


### PR DESCRIPTION
If the content of the procs variable is very short we assume it's just a newline, print all values as zero and exit. This avoids calling awk without any files which would make it wait for input indefinitely.
